### PR TITLE
Use long urls instead of short urls

### DIFF
--- a/templates/app.html
+++ b/templates/app.html
@@ -42,7 +42,7 @@ angular.module('urlApp', ['ngSanitize'], function($locationProvider) {
 		}
 
 		function calculateSharingUrl(state) {
-			return state.shortUrl + '?CMP=' + state.selectedShortCode.code;
+			return state.url + '?CMP=' + state.selectedShortCode.code;
 		}
 
 		function determinePath(url) {


### PR DESCRIPTION
We have used short urls in the past because it was allowing us to embed urls more easily in twitter. However [twitter now shortened every urls (even the short ones)](https://support.twitter.com/articles/78124) which means short urls only add `3` redirections that increase the latency before accessing the article (See https://github.com/guardian/content-api-transformer/pull/8). The latency increase is more important with `https`.
#### Related pull-requests
-  [Removal of short urls in transformer](https://github.com/guardian/content-api-transformer/pull/8)
-  [Removal of short urls in iOs app](https://github.com/guardian/ios-live/pull/2476)

@JustinPinner @rrees 
